### PR TITLE
Fix display of nonexistent forms

### DIFF
--- a/src/pages/formdatapage/formdatapage.jsx
+++ b/src/pages/formdatapage/formdatapage.jsx
@@ -74,7 +74,11 @@ export default function FormDataPage({ setLoggedIn }) {
         });
         const formsData = await formsRes.json();
         const match = formsData.find(f => f.id === formId);
-        if (match) setTitle(match.title);
+        if (match) {
+            setTitle(match.title);
+        } else {
+            setTitle("Form not found"); // ← show this if the form doesn't exist
+        }   
 
         } catch (err) {
         console.error(err);


### PR DESCRIPTION
Fixed it so that if someone manually types a random form name into the URL it just displays an empty datatable and the header says "Form not found".