### PR TITLE
Fix bug. Link invisible when in dark mode.

### DIFF
--- a/src/pages/FormBuilder/FormBuilder.jsx
+++ b/src/pages/FormBuilder/FormBuilder.jsx
@@ -178,7 +178,11 @@ function FormBuilder({ setLoggedIn }) {
                     </Tooltip>
                   </InputAdornment>
                 ),
-                sx: { borderRadius: '12px', bgcolor: '#f9f9f9' }
+                sx: {
+                  borderRadius: '12px',
+                  bgcolor: 'action.hover',
+                  color: 'text.secondary',
+                }
               }}
             />
           </DialogContent>


### PR DESCRIPTION


Before fix/current prod:

<img width="1917" height="970" alt="Screenshot 2026-04-20 110227" src="https://github.com/user-attachments/assets/0cfe6f8b-41af-487d-82bc-935405aa44d3" />




After fix is below:
<img width="1908" height="960" alt="Screenshot 2026-04-20 111337" src="https://github.com/user-attachments/assets/02918641-e06b-4a1f-aef5-d0c800c5d643" />

