### PR TITLE
Add QR code generation to go with form links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^7.3.9",
         "@mui/material": "^7.3.10",
         "@mui/x-data-grid": "^8.28.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1"
@@ -3253,6 +3254,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^7.3.9",
     "@mui/material": "^7.3.10",
     "@mui/x-data-grid": "^8.28.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1"

--- a/src/pages/FormBuilder/FormBuilder.jsx
+++ b/src/pages/FormBuilder/FormBuilder.jsx
@@ -12,6 +12,8 @@ import SaveIcon from '@mui/icons-material/Save';
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import DownloadIcon from '@mui/icons-material/Download';
+import { QRCodeCanvas } from 'qrcode.react'; // <-- NEW IMPORT
 import Layout from "../../components/Layout";
 
 function FormBuilder({ setLoggedIn }) {
@@ -23,7 +25,7 @@ function FormBuilder({ setLoggedIn }) {
   
   // Modal States
   const [openConfirm, setOpenConfirm] = useState(false);
-  const [publishedUrl, setPublishedUrl] = useState(""); // Stores the URL after creation
+  const [publishedUrl, setPublishedUrl] = useState(""); 
 
   const addField = () => setFields([...fields, { id: "", label: "", type: "text", required: false }]);
 
@@ -45,7 +47,7 @@ function FormBuilder({ setLoggedIn }) {
   };
 
   const handleFinalSubmit = async () => {
-    const lowerOrg = organization.toLowerCase(); // Force lowercase
+    const lowerOrg = organization.toLowerCase(); 
     const formId = `form_${lowerOrg}_${title.toLowerCase().replace(/\s+/g, "_")}`;
     
     const payload = { 
@@ -86,7 +88,20 @@ function FormBuilder({ setLoggedIn }) {
 
   const copyToClipboard = () => {
     navigator.clipboard.writeText(publishedUrl);
-    // You could add a small toast notification here if you wanted!
+  };
+
+  // --- NEW: Function to download the QR code as a PNG ---
+  const downloadQRCode = () => {
+    const canvas = document.getElementById("qr-code-canvas");
+    if (canvas) {
+      const pngUrl = canvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
+      let downloadLink = document.createElement("a");
+      downloadLink.href = pngUrl;
+      downloadLink.download = `${title.toLowerCase().replace(/\s+/g, "_")}_QR.png`;
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      document.body.removeChild(downloadLink);
+    }
   };
 
   return (
@@ -150,18 +165,47 @@ function FormBuilder({ setLoggedIn }) {
           </DialogActions>
         </Dialog>
 
-        {/* STEP 2: SUCCESS DIALOG (SHOWS THE LINK) */}
+        {/* STEP 2: SUCCESS DIALOG (SHOWS LINK & QR CODE) */}
         <Dialog 
           open={Boolean(publishedUrl)} 
           onClose={() => setPublishedUrl("")}
-          PaperProps={{ sx: { borderRadius: '24px', p: 2, textAlign: 'center' } }}
+          PaperProps={{ sx: { borderRadius: '24px', p: 2, textAlign: 'center', minWidth: '350px' } }}
         >
           <DialogContent>
-            <CheckCircleOutlineIcon sx={{ fontSize: 60, color: 'success.main', mb: 2 }} />
+            <CheckCircleOutlineIcon sx={{ fontSize: 60, color: 'success.main', mb: 1 }} />
             <DialogTitle fontWeight="800" sx={{ p: 0, mb: 1 }}>Form Published!</DialogTitle>
             <DialogContentText sx={{ mb: 3 }}>
-              Your form is live and ready to accept responses. Share the link below:
+              Your form is live! Share the link or print the QR code below.
             </DialogContentText>
+
+            {/* --- NEW: QR Code Display --- */}
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 3 }}>
+              <Paper 
+                elevation={0} 
+                sx={{ 
+                  p: 2, 
+                  border: '2px dashed', 
+                  borderColor: 'divider',
+                  borderRadius: '16px',
+                  display: 'inline-block'
+                }}
+              >
+                <QRCodeCanvas 
+                  id="qr-code-canvas" 
+                  value={publishedUrl} 
+                  size={160} 
+                  level={"H"} // High error correction so it scans easily on phones
+                  includeMargin={true}
+                />
+              </Paper>
+              <Button 
+                startIcon={<DownloadIcon />} 
+                onClick={downloadQRCode} 
+                sx={{ mt: 2, textTransform: 'none', fontWeight: 600 }}
+              >
+                Download QR Code
+              </Button>
+            </Box>
             
             <TextField
               fullWidth
@@ -190,7 +234,7 @@ function FormBuilder({ setLoggedIn }) {
             <Button 
               onClick={() => navigate(`/${organization}`)} 
               variant="contained"
-              sx={{ borderRadius: '8px', px: 4 }}
+              sx={{ borderRadius: '8px', px: 4, textTransform: 'none', fontWeight: 600 }}
             >
               Return to Dashboard
             </Button>

--- a/src/pages/FormDataPage/FormDataPage.jsx
+++ b/src/pages/FormDataPage/FormDataPage.jsx
@@ -5,13 +5,19 @@ import {
   GridRowModes,
   GridRowEditStopReasons,
 } from "@mui/x-data-grid";
-import { Typography, Box, Button, IconButton, Tooltip } from "@mui/material";
+import { 
+  Typography, Box, Button, IconButton, Tooltip,
+  Paper, Dialog, DialogTitle, DialogContent, DialogActions // <-- NEW IMPORTS
+} from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import SaveIcon from "@mui/icons-material/Save";
 import CancelIcon from "@mui/icons-material/Cancel";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
+import QrCodeIcon from '@mui/icons-material/QrCode'; // <-- NEW IMPORT
+import DownloadIcon from '@mui/icons-material/Download'; // <-- NEW IMPORT
+import { QRCodeCanvas } from 'qrcode.react'; // <-- NEW IMPORT
 
 import Layout from "../../components/Layout";
 
@@ -31,6 +37,9 @@ export default function FormDataPage({ setLoggedIn }) {
   const [loading, setLoading] = useState(true);
   const [formUrl, setFormUrl] = useState("");
   const [copied, setCopied] = useState(false);
+  
+  // --- NEW STATE: Controls the QR Modal ---
+  const [qrDialogOpen, setQrDialogOpen] = useState(false);
 
   const isEditing =
     selectedRowId !== null &&
@@ -107,6 +116,20 @@ export default function FormDataPage({ setLoggedIn }) {
     navigator.clipboard.writeText(formUrl);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000); // Swaps icon back after 2 seconds
+  };
+
+  // --- NEW FUNCTION: Download QR Code ---
+  const downloadQRCode = () => {
+    const canvas = document.getElementById("qr-code-canvas-data");
+    if (canvas) {
+      const pngUrl = canvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
+      let downloadLink = document.createElement("a");
+      downloadLink.href = pngUrl;
+      downloadLink.download = `${title.toLowerCase().replace(/\s+/g, "_")}_QR.png`;
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      document.body.removeChild(downloadLink);
+    }
   };
 
   useEffect(() => {
@@ -320,36 +343,89 @@ export default function FormDataPage({ setLoggedIn }) {
           </Box>
 
           <Box 
-          sx={{ 
-            display: 'flex', 
-            justifyContent: 'flex-start', 
-            alignItems: 'center', 
-            mb: 4, 
-            mt: 1,
-            gap: 1 
-          }}
-        >
-          <Typography 
-            variant="body2" 
-            sx={(theme) => ({ 
-              color: 'text.secondary', 
-              bgcolor: theme.palette.action.hover, // Auto-adapts perfectly
-              px: 1.5, 
-              py: 0.5, 
-              borderRadius: '4px', 
-              border: `1px solid ${theme.palette.divider}`,
-              fontSize: '0.8rem'
-            })}
+            sx={{ 
+              display: 'flex', 
+              justifyContent: 'flex-start', 
+              alignItems: 'center', 
+              mb: 4, 
+              mt: 1,
+              gap: 1 
+            }}
           >
-            {formUrl}
-          </Typography>
-          <Tooltip title={copied ? "Copied!" : "Copy Link"}>
-            <IconButton size="small" onClick={handleCopyLink} color={copied ? "success" : "primary"}>
-              {copied ? <CheckIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
-            </IconButton>
-          </Tooltip>
+            <Typography 
+              variant="body2" 
+              sx={(theme) => ({ 
+                color: 'text.secondary', 
+                bgcolor: theme.palette.action.hover, // Auto-adapts perfectly
+                px: 1.5, 
+                py: 0.5, 
+                borderRadius: '4px', 
+                border: `1px solid ${theme.palette.divider}`,
+                fontSize: '0.8rem'
+              })}
+            >
+              {formUrl}
+            </Typography>
+            <Tooltip title={copied ? "Copied!" : "Copy Link"}>
+              <IconButton size="small" onClick={handleCopyLink} color={copied ? "success" : "primary"}>
+                {copied ? <CheckIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
+            
+            {/* --- NEW: QR Code Trigger Button --- */}
+            {formUrl && (
+              <Tooltip title="View QR Code">
+                <IconButton size="small" onClick={() => setQrDialogOpen(true)} color="primary">
+                  <QrCodeIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            )}
+          </Box>
         </Box>
-        </Box>
+
+        {/* --- NEW: QR Code Modal --- */}
+        <Dialog 
+          open={qrDialogOpen} 
+          onClose={() => setQrDialogOpen(false)}
+          PaperProps={{ sx: { borderRadius: '24px', p: 2, textAlign: 'center', minWidth: '300px' } }}
+        >
+          <DialogTitle fontWeight="800">Form QR Code</DialogTitle>
+          <DialogContent>
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mt: 2 }}>
+              <Paper 
+                elevation={0} 
+                sx={{ 
+                  p: 2, 
+                  border: '2px dashed', 
+                  borderColor: 'divider',
+                  borderRadius: '16px',
+                  display: 'inline-block'
+                }}
+              >
+                <QRCodeCanvas 
+                  id="qr-code-canvas-data" 
+                  value={formUrl || "https://"} 
+                  size={160} 
+                  level={"H"} 
+                  includeMargin={true}
+                />
+              </Paper>
+              <Button 
+                startIcon={<DownloadIcon />} 
+                onClick={downloadQRCode} 
+                variant="contained"
+                sx={{ mt: 3, textTransform: 'none', fontWeight: 600, borderRadius: '8px' }}
+              >
+                Download PNG
+              </Button>
+            </Box>
+          </DialogContent>
+          <DialogActions sx={{ justifyContent: 'center', pb: 2 }}>
+            <Button onClick={() => setQrDialogOpen(false)} color="inherit" sx={{ fontWeight: 600, textTransform: 'none' }}>
+              Close
+            </Button>
+          </DialogActions>
+        </Dialog>
 
       </Box>
     </Layout>


### PR DESCRIPTION
Added QR code generation for links to forms.

Shows up upon creation of form, and displayed right next to the link in the form data page on the admin side. Always accessible to share.

Pics below:

<img width="1876" height="942" alt="Screenshot 2026-04-21 163642" src="https://github.com/user-attachments/assets/9c104f65-0f49-4e29-85a5-33969572b674" />

<img width="1901" height="962" alt="Screenshot 2026-04-21 163750" src="https://github.com/user-attachments/assets/3d3af0e1-60e5-45dc-9e10-a7eaf7faa8ff" />

<img width="563" height="816" alt="Screenshot 2026-04-21 164051" src="https://github.com/user-attachments/assets/98ac9fd1-7e90-4b82-943f-899dbbc98d3c" />